### PR TITLE
Fix ide support

### DIFF
--- a/examples/app/src/main/java/module-info.java
+++ b/examples/app/src/main/java/module-info.java
@@ -1,2 +1,3 @@
 module de.infolektuell.bass.app {
+    requires java.base;
 }

--- a/plugin/src/main/java/de/infolektuell/gradle/jextract/GradleJextractPlugin.java
+++ b/plugin/src/main/java/de/infolektuell/gradle/jextract/GradleJextractPlugin.java
@@ -122,6 +122,7 @@ public abstract class GradleJextractPlugin implements Plugin<@NonNull Project> {
                     task.getUseSystemLoadLibrary().convention(lib.getUseSystemLoadLibrary());
                     task.getGenerateSourceFiles().convention(lib.getGenerateSourceFiles());
                     task.getSources().convention(lib.getOutput());
+                    task.getClasses().convention(project.getLayout().getBuildDirectory().dir("generated/classes/jextract/java/" + lib.getName()));
                 });
 
                 project.getTasks().register(lib.getDumpIncludesTaskName(), JextractDumpIncludesTask.class, task -> {
@@ -138,11 +139,11 @@ public abstract class GradleJextractPlugin implements Plugin<@NonNull Project> {
                 s.getExtensions().add(SourceSetExtension.EXTENSION_NAME, sourceSetExtension);
                 sourceSetExtension.getLibraries().all(lib -> {
                     final TaskProvider<@NonNull JextractGenerateTask> task = project.getTasks().named(lib.getGenerateBindingsTaskName(), JextractGenerateTask.class);
-                    s.getJava().srcDir(task);
-                    s.getResources().srcDir(task);
-                    final FileCollection src = project.getLayout().files(task);
-                    s.setCompileClasspath(s.getCompileClasspath().plus(src));
-                    s.setRuntimeClasspath(s.getRuntimeClasspath().plus(src));
+                    s.getJava().srcDir(task.flatMap(t -> t.getSources()));
+                    s.getResources().srcDir(task.flatMap(t -> t.getSources()));
+                    final FileCollection classes = project.getLayout().files(task.flatMap(t -> t.getClasses()));
+                    s.setCompileClasspath(s.getCompileClasspath().plus(classes));
+                    s.setRuntimeClasspath(s.getRuntimeClasspath().plus(classes));
                 });
             });
             javaExtension.getSourceSets().named("main", s -> configureJmod(project, s));

--- a/plugin/src/main/java/de/infolektuell/gradle/jextract/GradleJextractPlugin.java
+++ b/plugin/src/main/java/de/infolektuell/gradle/jextract/GradleJextractPlugin.java
@@ -139,9 +139,9 @@ public abstract class GradleJextractPlugin implements Plugin<@NonNull Project> {
                 s.getExtensions().add(SourceSetExtension.EXTENSION_NAME, sourceSetExtension);
                 sourceSetExtension.getLibraries().all(lib -> {
                     final TaskProvider<@NonNull JextractGenerateTask> task = project.getTasks().named(lib.getGenerateBindingsTaskName(), JextractGenerateTask.class);
-                    s.getJava().srcDir(task.flatMap(t -> t.getSources()));
-                    s.getResources().srcDir(task.flatMap(t -> t.getSources()));
-                    final FileCollection classes = project.getLayout().files(task.flatMap(t -> t.getClasses()));
+                    s.getJava().srcDir(task.flatMap(JextractGenerateTask::getSources));
+                    s.getResources().srcDir(task.flatMap(JextractGenerateTask::getSources));
+                    final FileCollection classes = project.getLayout().files(task.flatMap(JextractGenerateTask::getClasses));
                     s.setCompileClasspath(s.getCompileClasspath().plus(classes));
                     s.setRuntimeClasspath(s.getRuntimeClasspath().plus(classes));
                 });

--- a/plugin/src/main/java/de/infolektuell/gradle/jextract/tasks/JextractGenerateTask.java
+++ b/plugin/src/main/java/de/infolektuell/gradle/jextract/tasks/JextractGenerateTask.java
@@ -102,6 +102,8 @@ public abstract class JextractGenerateTask extends JextractBaseTask {
         getFileSystemOperations().delete(spec -> spec.delete(getSources().getAsFileTree().matching(m -> m.include("**/*.class"))));
     }
 
+    /// Inject the build service for file system operations.
+    /// @return The injected build service
     @Inject
     protected abstract FileSystemOperations getFileSystemOperations();
 

--- a/plugin/src/main/java/de/infolektuell/gradle/jextract/tasks/JextractGenerateTask.java
+++ b/plugin/src/main/java/de/infolektuell/gradle/jextract/tasks/JextractGenerateTask.java
@@ -2,6 +2,7 @@ package de.infolektuell.gradle.jextract.tasks;
 
 import de.infolektuell.gradle.jextract.service.JextractStore;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
@@ -11,6 +12,7 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.process.ExecSpec;
 import org.jspecify.annotations.NonNull;
 
+import javax.inject.Inject;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -71,6 +73,11 @@ public abstract class JextractGenerateTask extends JextractBaseTask {
     @OutputDirectory
     public abstract DirectoryProperty getSources();
 
+    /// The directory where to place generated compiled class files
+    /// @return a directory property
+    @OutputDirectory
+    public abstract DirectoryProperty getClasses();
+
     /// Task action that uses Jextract to generate Java bindings
     @TaskAction
     protected final void generateBindings() {
@@ -87,7 +94,16 @@ public abstract class JextractGenerateTask extends JextractBaseTask {
                 jextract.exec(installationPath, spec -> commonExec(version, spec));
             }
         }
+        getFileSystemOperations().copy(spec -> {
+            spec.from(getSources());
+            spec.into(getClasses());
+            spec.include("**/*.class");
+        });
+        getFileSystemOperations().delete(spec -> spec.delete(getSources().getAsFileTree().matching(m -> m.include("**/*.class"))));
     }
+
+    @Inject
+    protected abstract FileSystemOperations getFileSystemOperations();
 
     private void commonExec(int version, ExecSpec spec) {
         getIncludes().get().forEach(it -> spec.args("-I", it));


### PR DESCRIPTION
This pR fixes some IDE-specific problems of correctly recognizing generated sources and classes.

The generated outputs directory was configured as source directory and added to the compile and runtime classpath at the same time.
IntelliJ regards that directory as library root instead of a source root and to displays incorrect error messages.

- The Jextract code generation task outputs source and class files into distinct output directories.
- Both are respectively added to the source set, sources as source directory, classes appended to the classpath.
